### PR TITLE
Add rule to handle removal of a replicated cache filestore

### DIFF
--- a/src/main/resources/infinispan
+++ b/src/main/resources/infinispan
@@ -217,3 +217,8 @@ modifyRepCacheLocking.rule=/subsystem=infinispan/cache-container=${name(../../..
 match.removeRepCacheLocking=remove:/cache-container/*/replicated-cache/*/locking/*
 removeRepCacheLocking.precedence=44
 removeRepCacheLocking.rule=/subsystem=infinispan/cache-container=${name(../../../..)}/replicated-cache=${name(../..)}/locking=${name(.)}:remove
+
+match.removeReplicatedCacheFileStore=remove:/cache-container/*/replicated-cache/*/file-store/*
+removeReplicatedCacheFileStore.precedence=80
+removeReplicatedCacheFileStore.rule=/subsystem=infinispan/cache-container=${name(../../../..)}/replicated-cache=${name(../..)}/file-store=${name(.)}:remove
+removeReplicatedCacheFileStore.refresh=true


### PR DESCRIPTION
Burak,

This rule is necessary to handle removal of the file-store from a replicated cache.
ie:

``` json
{
  "infinispan" => {
    "cache-container"=> { 
        "web" => {
        "replicated-cache" => {
            "repl" => {
                "file-store" => {
                "FILE_STORE" => "deleted",
            }
        }
    }}
    }}
}
```
