### PR TITLE
Added support to unmanaged deployments using unmanaged parameter.

### DIFF
--- a/src/main/java/com/redhat/jcliff/Deployment.java
+++ b/src/main/java/com/redhat/jcliff/Deployment.java
@@ -104,7 +104,8 @@ public class Deployment {
                                 child.get(col);
                             int i=0;
                             for(String val:values) {
-                                child.get(columnNames.get(i++)).set(val);
+                                if(i <=3)
+                                    child.get(columnNames.get(i++)).set(val);
                             }
                         }
                     }


### PR DESCRIPTION
I've added this patch in my local jcliff to add support to unmanaged deployments using jcliff. A new parameter unmanaged is parsed in deployments config files. If it's "true", deployment is unmanaged, otherwise is managed.

Additionally I've fixed an error when deployments return status "no metrics available" instead of "OK"
