### PR TITLE
fixes 'sytem' typo, adds modification support for jms-{queue,topic} resources

### DIFF
--- a/src/main/resources/logging
+++ b/src/main/resources/logging
@@ -29,7 +29,7 @@ remove.refresh=true
 
 match.addFileHandler=add:/file-handler/*
 addFileHandler.precedence=50
-addFileHandler.rule=/subsytem=logging/file-handler=${name(.)}:add(file={"path"=>${value(./file/path/.)},"relative-to"=>${value(./file/relative-to/.)}})
+addFileHandler.rule=/subsystem=logging/file-handler=${name(.)}:add(file={"path"=>${value(./file/path/.)},"relative-to"=>${value(./file/relative-to/.)}})
 addFileHandler.refresh=true
 
 match.modifyFileHandlerFile=modify:/file-handler/*/file
@@ -104,7 +104,7 @@ assignLoggerHandler.rule=/subsystem=logging/logger=${name(../..)}:assign-handler
 assignLoggerHandler.precedence=1100
 
 match.removeLoggerHandler=remove:/logger/*/handlers/*
-removeLoggerHandler.rule=/subsytem=logging/logger=${name(../..)}:unassign-handler(name=${value(.)})
+removeLoggerHandler.rule=/subsystem=logging/logger=${name(../..)}:unassign-handler(name=${value(.)})
 removeLoggerHandler.precedence=1100
 
 match.modifyParentHandlers=modify:/logger/*/use-parent-handlers

--- a/src/main/resources/mail
+++ b/src/main/resources/mail
@@ -25,7 +25,7 @@ addSession.precedence=10
 addSession.refresh=true
 
 match.removeSession=remove:/mail-session/*
-removeSession.rule=/subsystem=mail/mail-session:${name(.)}:remove
+removeSession.rule=/subsystem=mail/mail-session=${name(.)}:remove
 removeSession.precedence=10
 removeSession.refresh=true
 
@@ -42,9 +42,9 @@ addSmtp.refresh=true
 
 
 match.removeSmtp=remove:/mail-session/*/server/smtp
-removeSmtp.rule=/subsystem=mail/mail-session/${name(../..)}/server=smtp:remove
+removeSmtp.rule=/subsystem=mail/mail-session=${name(../..)}/server=smtp:remove
 removeSmtp.precedence=30
 removeSmtp.refresh=true
 
 match.smtpProps=modify:/mail-session/*/server/smtp/*
-smtpProps.rule=/subsytem=mail/mail-session/${name(../../..)}/server=smtp:write-attribute(name=${name(.)},value=${value(.)})
+smtpProps.rule=/subsystem=mail/mail-session=${name(../../..)}/server=smtp:write-attribute(name=${name(.)},value=${value(.)})

--- a/src/main/resources/messaging
+++ b/src/main/resources/messaging
@@ -14,9 +14,17 @@ match.addQueue=add:/messaging/hornetq-server/*/jms-queue/*
 addQueue.rule=jms-queue add --queue-address=${name(.)} --entries=${value(entries)} --durable=${value(durable)}
 addQueue.precedence=20
 
+match.modifyQueue=modify:/messaging/hornetq-server/*/jms-queue/*/*
+modifyQueue.rule=/subsystem=messaging/hornetq-server=${name(../../..)}/jms-queue=${name(..)}:write-attribute(name=${name(.)}, value=${value(.)}
+modifyQueue.precedence=25
+
 match.addTopic=add:/messaging/hornetq-server/*/jms-topic/*
 addTopic.rule=jms-topic add --topic-address=${name(.)} --entries=${value(entries)}  
 addTopic.precedence=20
+
+match.modifyTopic=modify:/messaging/hornetq-server/*/jms-topic/*/*
+modifyTopic.rule=/subsystem=messaging/hornetq-server=${name(../../..)}/jms-topic=${name(..)}:write-attribute(name=${name(.)}, value=${value(.)}
+modifyTopic.precedence=25
 
 match.modifyConFactory=modify:/messaging/hornetq-server/*/connection-factory/*/*
 modifyConFactory.rule=/subsystem=messaging/hornetq-server=${name(../../..)}/connection-factory=${name(..)}:write-attribute(name=${name(.)}, value=${value(.)}

--- a/src/main/resources/remoting
+++ b/src/main/resources/remoting
@@ -20,7 +20,7 @@ getContents=/subsystem=remoting:read-resource(recursive=true)
 client.preprocess.strip=/remoting
 
 match.modProps=modify:/*
-modProps.rule=/subsytem=remoting:write-attribute(name=${name(.)},value=${value(.)})
+modProps.rule=/subsystem=remoting:write-attribute(name=${name(.)},value=${value(.)})
 modProps.precedence=100
 
 


### PR DESCRIPTION
I've noticed a few typos in the rules ('sytem' instead of 'system', / or : instead of =) and I've added modification support for jms-queue and jms-topic.