### PR TITLE
Issue #57 xa datasource requires you to set  URL

### DIFF
--- a/src/main/resources/xadatasource
+++ b/src/main/resources/xadatasource
@@ -20,7 +20,7 @@ getContents=/subsystem=datasources:read-children-resources(child-type=xa-data-so
 server.preprocess.prepend=/xadatasource
 
 match.add=add:/xadatasource/*
-add.rule.1=xa-data-source add --name=${name(.)} --jndi-name=${value(jndi-name)} --driver-name=${value(driver-name)} --xa-datasource-properties=[{URL=${value(xa-datasource-properties/URL/value)}}]
+add.rule.1=xa-data-source add --name=${name(.)} --jndi-name=${value(jndi-name)} --driver-name=${value(driver-name)}
 add.rule.2=if result.value==false of /subsystem=datasources/xa-datasource=${name(.)}:read-resource 
 add.rule.3=xa-data-source enable --name=${name(.)}
 add.rule.4=:reload


### PR DESCRIPTION
xa datasource requires you to set xa-datasource-properties for URL but
not all jdbc drivers support this property, such as postgresql.