### PR TITLE
Fixed naming/binding add command to include mandatory value attribute

### DIFF
--- a/src/main/resources/naming
+++ b/src/main/resources/naming
@@ -19,9 +19,8 @@ name=naming
 getContents=/subsystem=naming:read-resource(recursive=true)
 client.preprocess.strip=/naming
 
-
 match.addBinding=add:/binding/*
-addBinding.rule.1=/subsystem=naming/binding="${name(.)}":add(binding-type=${value(binding-type)})
+addBinding.rule.1=/subsystem=naming/binding="${name(.)}":add(binding-type=${value(binding-type)},value=${value(./value)})
 addBinding.refresh=true
 
 match.modifyBinding=modify:/binding/*/*


### PR DESCRIPTION
I found this rule to be non-functional, but the fix was relatively simple.