### PR TITLE
Report when JCliff has apply change

### DIFF
--- a/src/main/java/com/redhat/jcliff/Ctx.java
+++ b/src/main/java/com/redhat/jcliff/Ctx.java
@@ -51,6 +51,7 @@ public class Ctx {
     public final List<String> cmdQueue=new ArrayList<String>();
     public boolean leaveTmp=false;
     public String prepend=null;
+    public boolean cmdQueueProcessed=false;
 
     public void log(String s) {
         if(log)
@@ -141,6 +142,7 @@ public class Ctx {
 
     public ModelNode[] runQueuedCmds(Postprocessor p) {
         if(!cmdQueue.isEmpty()) {
+            this.cmdQueueProcessed = true;
             ModelNode[] ret=runcmd(getQueuedCmds(),p);
             cmdQueue.clear();
             return ret;

--- a/src/main/java/com/redhat/jcliff/Main.java
+++ b/src/main/java/com/redhat/jcliff/Main.java
@@ -272,9 +272,9 @@ public class Main {
                     if(reload)
                         if(reloadRequired(ctx))
                             ctx.reloadConf();
-                    
+
                 }
-                
+
                 // Deal with deployments
                 ctx.log("Processing deployments");
                 ctx.batch=false; // Don't batch them
@@ -323,6 +323,7 @@ public class Main {
                     if(names.length>0)
                         deployment.undeploy(names);
                 }
+                ctx.log("Server configuration changed: " + ctx.cmdQueueProcessed);
 
                 if(reload)
                     if(reloadRequired(ctx))


### PR DESCRIPTION
Tools like Ansible reports when the server configuration has been changed, so this change to jcliff's code provides a mechanism for tool like Ansible to retrieve the information from the
output.