### PR TITLE
Retrieving extensions doesn't work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ target
 .classpath
 .project
 .settings/
+.idea
+*.iml

--- a/src/main/resources/extension
+++ b/src/main/resources/extension
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name=extension
-getContents=/extension=:read-children-resources(child-type=extension)
+getContents=:read-children-resources(child-type=extension)
 server.preprocess.prepend=/extension
 
 match.addExtension=add:/extension/*

--- a/src/main/scripts/jcliff
+++ b/src/main/scripts/jcliff
@@ -60,7 +60,12 @@ for jar in ${JCLIFF_DEPS_DIR}/*.jar ; do
     CLASSPATH="${jar}:${CLASSPATH}"
 done
 
-"${JAVA}" -classpath "${CLASSPATH}" 'com.redhat.jcliff.Main' \
+JAVA_ARGS=${JAVA_ARGS:-''}
+# uncomment to enable debugging:
+#JAVA_ARGS="$JAVA_ARGS -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"
+
+"${JAVA}" $JAVA_ARGS \
+          -classpath "${CLASSPATH}" 'com.redhat.jcliff.Main' \
           --cli="${JBOSS_HOME}/bin/jboss-cli.sh" ${CONTROLLER} \
           --timeout="${JBOSS_CLI_TIMEOUT}" \
           --ruledir="${JCLIFF_RULES_DIR}"     \


### PR DESCRIPTION
When running on following script:

```
{
  "extension" => {
    "org.keycloak.keycloak-saml-adapter-subsystem" => ""
  }
}
```

jcliff fails with:

```
2020-02-05 15:51:27:0730: /extension=:read-children-resources(child-type=extension)
2020-02-05 16:01:22:0647: java.lang.ArrayIndexOutOfBoundsException: -1
	at com.redhat.jcliff.Main.refreshServerNode(Main.java:425)
	at com.redhat.jcliff.Main.main(Main.java:240)
```

The issue is wrong getContents command in the extensions rule:

`getContents=/extension=:read-children-resources(child-type=extension)`

while it should correctly be:

`getContents=:read-children-resources(child-type=extension)`